### PR TITLE
chore: ignore network proxy letsencrypt dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /uploads
 /letsencrypt
+
+# Local Let's Encrypt data; recreate locally rather than commit
+network_proxy/letsencrypt/


### PR DESCRIPTION
## Summary
- ignore network_proxy/letsencrypt directory so developers keep their own certs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aed24f14a083208cbcfa3ead4f1fbd