### PR TITLE
Initialize Let's Encrypt storage before Traefik startup

### DIFF
--- a/dev_up.sh
+++ b/dev_up.sh
@@ -13,6 +13,8 @@ fi
 
 echo "Using DEV_DOMAIN=${DEV_DOMAIN}"
 
+scripts/init-letsencrypt.sh
+
 # Bring up Traefik (HTTP only) + stacks with dev overrides
 docker compose -f network_proxy/compose.yaml -f network_proxy/compose.override.dev.yaml up -d
 docker compose -f stacks/compose.yaml -f stacks/compose.override.dev.yaml up -d espenmunthe

--- a/scripts/init-letsencrypt.sh
+++ b/scripts/init-letsencrypt.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+LE_DIR="$(dirname "$0")/../network_proxy/letsencrypt"
+mkdir -p "$LE_DIR"
+touch "$LE_DIR/acme.json"
+chmod 600 "$LE_DIR/acme.json"

--- a/startup.sh
+++ b/startup.sh
@@ -61,6 +61,8 @@ compose_down "$BANDY_COMPOSE"
 compose_down "$MAIN_COMPOSE"
 compose_down "$PROXY_COMPOSE"
 
+"${PROJECT_ROOT}/scripts/init-letsencrypt.sh"
+
 echo ">> Bringing Traefik (proxy) UP"
 compose_up "$PROXY_COMPOSE"
 


### PR DESCRIPTION
## Summary
- add `scripts/init-letsencrypt.sh` to prepare Traefik's ACME storage
- ensure `startup.sh` and `dev_up.sh` invoke init script before starting Traefik

## Testing
- `bash -n startup.sh dev_up.sh scripts/init-letsencrypt.sh`
- `scripts/init-letsencrypt.sh`


------
https://chatgpt.com/codex/tasks/task_e_68aed34f003883209aae7977acb9669a