### PR TITLE
Remove TLS certresolver from espenmunthe dev override

### DIFF
--- a/stacks/compose.override.dev.yaml
+++ b/stacks/compose.override.dev.yaml
@@ -1,9 +1,8 @@
 services:
   espenmunthe:
     labels:
-      - "traefik.enable=true"
-      - "traefik.docker.network=web"
-      - "traefik.http.routers.espen.entrypoints=web"
-      - "traefik.http.routers.espen.rule=Host(`espenmunthe.${DEV_DOMAIN}`) || Host(`www.espenmunthe.${DEV_DOMAIN}`)"
-      - "traefik.http.routers.espen.tls="
-      - "traefik.http.services.espen.loadbalancer.server.port=80"
+      traefik.enable: "true"
+      traefik.docker.network: "web"
+      traefik.http.routers.espen.entrypoints: "web"
+      traefik.http.routers.espen.rule: "Host(`espenmunthe.${DEV_DOMAIN}`) || Host(`www.espenmunthe.${DEV_DOMAIN}`)"
+      traefik.http.services.espen.loadbalancer.server.port: "80"


### PR DESCRIPTION
## Summary
- simplify espenmunthe development override to only use HTTP labels
- drop TLS certresolver configuration to avoid Traefik errors

## Testing
- `docker compose -f stacks/compose.yaml -f stacks/compose.override.dev.yaml config` *(fails: command not found)*
- `docker compose -f stacks/compose.yaml -f stacks/compose.override.dev.yaml up -d espenmunthe` *(fails: command not found)*
- `docker compose logs traefik` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aee3a5a2948320bcd4d3a86e45345a